### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -40,7 +40,7 @@ tests:
       run:
         - pytest-cov
         - pyyaml
-        - python ${{ python_min }}
+        - python ${{ python_min }}.*
     script:
       - coverage run --source configargparse --branch -m pytest -vv --tb=long --color=yes
       - coverage report --show-missing --skip-covered --fail-under 74


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{{{ python_min }}}}` to make them valid match specs.

This is a build-fix only — the existing package on conda-forge is unaffected, so no new build needs to be pushed. That's why the build number isn't bumped.